### PR TITLE
Fix decryption example

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,5 +93,5 @@ const ciphertext = ...; // Encrypted data
 // Decrypt the ciphertext using the key and the nonce
 const plaintextResult = Ascon.decrypt(key, nonce, ciphertext);
 
-const text = new TextEncoder().decode(plaintextResult); // "ascon"
+const text = new TextDecoder().decode(plaintextResult); // "ascon"
 ```


### PR DESCRIPTION
The [TextEncode()](https://developer.mozilla.org/en-US/docs/Web/API/TextEncoder) interface does not have the [decode](https://developer.mozilla.org/en-US/docs/Web/API/TextDecoder/decode) method.